### PR TITLE
chore: document night fairness guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,13 +11,16 @@ SQLite via SQLAlchemy; migrations via `make migrate`. Models: `Staff`, `Assignme
 - `make test` – run unit tests
 
 ## Guardrails
-- Never place more than one night TC leader per day
+- Never place more than one night TC leader per day (phase_night enforces via `placed_leader`)
 - Respect fixed assignments and off days as hard constraints
 - Balance GDV rank1/rank2 roughly 50/50; TC may join rank1 pool but not as extra night leaders
+- Fairness window is 7 days (`FairnessWindow`); keep `[FAIR]` logs in sync if you adjust rank math
 - Do not overwrite fixed placements; log `FIX_BLOCK` and surface via `/api/schedule/validate`
+- Night rescue (`ALLOW_OVERCAP_NIGHT_LEADER`) should stay emergency-only; never use it to bypass quota bugs
 
 ## Testing
 - Add unit tests for each engine change (night/day phases, fairness, validation)
+- Exercise both happy-path & quota edge cases (locked staff, fixed Đ@TD, fairness 7-day window)
 - `backend/tests/test_export_month_csv.py` must assert CSV has non‑empty rows
 
 ## APIs to know


### PR DESCRIPTION
## Summary
- clarify night phase guardrails around TC leaders, fairness logs, and emergency overcap usage
- expand testing guidance to cover fairness window and locked quota edge cases

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68de592ff0888320a413941c56e15f3b