### PR TITLE
Add holiday and month configuration tables

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,6 +1,7 @@
 # backend/models.py
 import os
 from datetime import date
+from enum import Enum as PyEnum
 from typing import List, Optional
 from urllib.parse import quote_plus
 
@@ -11,10 +12,13 @@ from sqlalchemy import (
     Float,
     ForeignKey,
     Integer,
+    JSON,
     String,
+    UniqueConstraint,
     create_engine,
     inspect,
 )
+from sqlalchemy import Enum as SAEnum
 from sqlalchemy.orm import (
     Mapped,
     declarative_base,
@@ -22,6 +26,7 @@ from sqlalchemy.orm import (
     relationship,
     sessionmaker,
 )
+from sqlalchemy.sql import expression
 
 from dotenv import load_dotenv
 
@@ -132,34 +137,147 @@ class Assignment(Base):
     staff: Mapped[Optional[Staff]] = relationship()
 
 
+
+class WeekendPolicy(str, PyEnum):
+    SAT_OFF = "sat_off"
+    SAT_WORK_AM = "sat_work_am"
+    SAT_WORK = "sat_work"
+
+
 class Holiday(Base):
-    __tablename__ = "holidays"
-    id = Column(Integer, primary_key=True)
-    day = Column(Date, unique=True, nullable=False)
-    name = Column(String, nullable=True)
+    __tablename__ = "holiday"
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    day: Mapped[date] = mapped_column(
+        "date", Date, unique=True, nullable=False
+    )
+    name: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    kind: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    official: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default=expression.false(),
+    )
+    source: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+
+
+class MonthConfig(Base):
+    __tablename__ = "month_config"
+    __table_args__ = (
+        UniqueConstraint("year", "month", name="uq_month_config_year_month"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    year: Mapped[int] = mapped_column(Integer, nullable=False)
+    month: Mapped[int] = mapped_column(Integer, nullable=False)
+    working_days_override: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    weekend_policy: Mapped[WeekendPolicy] = mapped_column(
+        SAEnum(WeekendPolicy, name="weekend_policy"),
+        nullable=False,
+        default=WeekendPolicy.SAT_OFF,
+        server_default=WeekendPolicy.SAT_OFF.value,
+    )
+    extra_workdays: Mapped[List[str]] = mapped_column(
+        JSON, nullable=False, default=list, server_default="[]"
+    )
+    extra_offdays: Mapped[List[str]] = mapped_column(
+        JSON, nullable=False, default=list, server_default="[]"
+    )
+
+
+class ShiftPlanDefaults(Base):
+    __tablename__ = "shift_plan_defaults"
+    __table_args__ = (
+        UniqueConstraint(
+            "year",
+            "month",
+            name="uq_shift_plan_defaults_year_month",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    year: Mapped[int] = mapped_column(Integer, nullable=False)
+    month: Mapped[int] = mapped_column(Integer, nullable=False)
+    day_shifts: Mapped[int] = mapped_column(Integer, nullable=False)
+    night_shifts: Mapped[int] = mapped_column(Integer, nullable=False)
+    leader_shifts: Mapped[int] = mapped_column(Integer, nullable=False)
+    pgd_shifts: Mapped[int] = mapped_column(Integer, nullable=False)
 
 
 def init_db():
     """Create tables and run lightweight migrations.
 
-    Ensures the ``fixed_assignment`` table always has the ``position`` column,
-    even for databases created before the column was introduced.
+    Ensures schema changes introduced over time are reflected when running in
+    environments without Alembic migrations.
     """
+
+    insp = inspect(engine)
+    try:
+        existing_tables = set(insp.get_table_names())
+    except Exception:
+        existing_tables = set()
+
+    if "holidays" in existing_tables and "holiday" not in existing_tables:
+        with engine.begin() as conn:
+            conn.exec_driver_sql("ALTER TABLE holidays RENAME TO holiday")
+        existing_tables.remove("holidays")
+        existing_tables.add("holiday")
+
     Base.metadata.create_all(engine)
 
-    # --- Migration: add ``position`` column if missing ---
     insp = inspect(engine)
     try:
         tables = set(insp.get_table_names())
     except Exception:
         return
 
-    if "fixed_assignment" not in tables:
-        return
+    # --- Migration: holiday table enhancements ---
+    if "holiday" in tables:
+        holiday_cols = {col["name"] for col in insp.get_columns("holiday")}
 
-    cols = {col["name"] for col in insp.get_columns("fixed_assignment")}
-    if "position" not in cols:
-        with engine.begin() as conn:
-            conn.exec_driver_sql(
-                "ALTER TABLE fixed_assignment ADD COLUMN position VARCHAR NULL"
-            )
+        if "day" in holiday_cols and "date" not in holiday_cols:
+            with engine.begin() as conn:
+                conn.exec_driver_sql("ALTER TABLE holiday RENAME COLUMN day TO date")
+            insp = inspect(engine)
+            holiday_cols = {col["name"] for col in insp.get_columns("holiday")}
+
+        if "kind" not in holiday_cols:
+            with engine.begin() as conn:
+                conn.exec_driver_sql(
+                    "ALTER TABLE holiday ADD COLUMN kind VARCHAR NULL"
+                )
+            insp = inspect(engine)
+            holiday_cols = {col["name"] for col in insp.get_columns("holiday")}
+
+        if "official" not in holiday_cols:
+            with engine.begin() as conn:
+                conn.exec_driver_sql(
+                    "ALTER TABLE holiday ADD COLUMN official BOOLEAN NOT NULL DEFAULT false"
+                )
+            insp = inspect(engine)
+            holiday_cols = {col["name"] for col in insp.get_columns("holiday")}
+
+        if "source" not in holiday_cols:
+            with engine.begin() as conn:
+                conn.exec_driver_sql(
+                    "ALTER TABLE holiday ADD COLUMN source VARCHAR NULL"
+                )
+
+        uniques = insp.get_unique_constraints("holiday")
+        has_date_unique = any(
+            "date" in constraint.get("column_names", []) for constraint in uniques
+        )
+        if not has_date_unique:
+            with engine.begin() as conn:
+                conn.exec_driver_sql(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS idx_holiday_date ON holiday(date)"
+                )
+
+    # --- Migration: add ``position`` column if missing ---
+    if "fixed_assignment" in tables:
+        cols = {col["name"] for col in insp.get_columns("fixed_assignment")}
+        if "position" not in cols:
+            with engine.begin() as conn:
+                conn.exec_driver_sql(
+                    "ALTER TABLE fixed_assignment ADD COLUMN position VARCHAR NULL"
+                )

--- a/tests/test_month_config_models.py
+++ b/tests/test_month_config_models.py
@@ -1,0 +1,117 @@
+import importlib
+import sqlite3
+from datetime import date
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+
+@pytest.fixture()
+def models(tmp_path, monkeypatch):
+    db_path = tmp_path / "config.db"
+    monkeypatch.setenv("DB_URL", f"sqlite:///{db_path}")
+    import models as models_module
+
+    importlib.reload(models_module)
+    models_module.init_db()
+    return models_module
+
+
+def test_month_config_unique_constraint(models):
+    with models.SessionLocal() as session:
+        cfg = models.MonthConfig(year=2025, month=1)
+        session.add(cfg)
+        session.commit()
+
+        assert cfg.extra_workdays == []
+        assert cfg.extra_offdays == []
+        assert cfg.weekend_policy == models.WeekendPolicy.SAT_OFF
+
+        session.add(models.MonthConfig(year=2025, month=1))
+        with pytest.raises(IntegrityError):
+            session.commit()
+        session.rollback()
+
+
+def test_shift_plan_defaults_unique_constraint(models):
+    with models.SessionLocal() as session:
+        defaults = models.ShiftPlanDefaults(
+            year=2025,
+            month=1,
+            day_shifts=10,
+            night_shifts=5,
+            leader_shifts=2,
+            pgd_shifts=1,
+        )
+        session.add(defaults)
+        session.commit()
+
+        session.add(
+            models.ShiftPlanDefaults(
+                year=2025,
+                month=1,
+                day_shifts=8,
+                night_shifts=4,
+                leader_shifts=1,
+                pgd_shifts=1,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            session.commit()
+        session.rollback()
+
+
+def test_init_db_migrates_legacy_holidays(tmp_path, monkeypatch):
+    db_path = tmp_path / "legacy.db"
+    monkeypatch.setenv("DB_URL", f"sqlite:///{db_path}")
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE holidays (id INTEGER PRIMARY KEY, day DATE NOT NULL, name VARCHAR)"
+    )
+    conn.execute(
+        "INSERT INTO holidays (id, day, name) VALUES (1, '2024-01-01', 'New Year')"
+    )
+    conn.commit()
+    conn.close()
+
+    import models as models_module
+
+    importlib.reload(models_module)
+    models_module.init_db()
+
+    with models_module.engine.connect() as raw_conn:
+        tables = {
+            row[0]
+            for row in raw_conn.exec_driver_sql(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        assert "holiday" in tables
+        assert "holidays" not in tables
+
+        columns = {
+            row[1]
+            for row in raw_conn.exec_driver_sql("PRAGMA table_info('holiday')").fetchall()
+        }
+        assert {"id", "date", "name", "kind", "official", "source"}.issubset(columns)
+
+        indexes = raw_conn.exec_driver_sql("PRAGMA index_list('holiday')").fetchall()
+        unique_index_names = [row[1] for row in indexes if row[2] == 1]
+        assert unique_index_names, "Expected a unique index on holiday(date)"
+        date_index_verified = False
+        for name in unique_index_names:
+            cols = raw_conn.exec_driver_sql(
+                f"PRAGMA index_info('{name}')"
+            ).fetchall()
+            if len(cols) == 1 and cols[0][2] == "date":
+                date_index_verified = True
+                break
+        assert date_index_verified, "holiday(date) should be unique"
+
+    with models_module.SessionLocal() as session:
+        rows = session.query(models_module.Holiday).all()
+        assert len(rows) == 1
+        assert rows[0].day == date(2024, 1, 1)
+        assert rows[0].name == "New Year"
+        assert rows[0].official is False


### PR DESCRIPTION
## Summary
- add schema models for holiday, month_config, and shift_plan_defaults with the required constraints
- extend init_db migrations to upgrade legacy holiday data to the new shape
- add regression tests that cover unique constraints and the holiday migration path

## Testing
- python -m pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68de6df1aa208320be712969208f0945