### PR TITLE
feat: add shift defaults API

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ from models import (
     Holiday,
     MonthConfig,
     OffDay,
+    ShiftPlanDefaults,
     SessionLocal,
     Staff,
     WeekendPolicy,
@@ -277,6 +278,21 @@ def _build_month_config_payload(session, year: int, month: int) -> dict:
         },
     }
     return payload
+
+
+def _serialize_shift_defaults(
+    defaults: ShiftPlanDefaults | None, year: int, month: int
+) -> dict:
+    """Return API payload describing stored shift plan defaults for a month."""
+
+    return {
+        "year": year,
+        "month": month,
+        "day_shifts": defaults.day_shifts if defaults else 0,
+        "night_shifts": defaults.night_shifts if defaults else 0,
+        "leader_shifts": defaults.leader_shifts if defaults else 0,
+        "pgd_shifts": defaults.pgd_shifts if defaults else 0,
+    }
 
 
 # ---------- Root / SPA ----------
@@ -848,6 +864,117 @@ def import_holidays():
     except Exception as e:
         return (
             jsonify({"ok": False, "error": f"Internal error: {e.__class__.__name__}: {e}"}),
+            500,
+        )
+
+
+# ---------- Shift plan defaults ----------
+@app.get("/api/shift-defaults")
+def get_shift_defaults():
+    try:
+        year, month = _parse_year_month(
+            request.args.get("year"), request.args.get("month")
+        )
+    except ValueError as exc:
+        return {"error": str(exc)}, 400
+    except Exception as exc:  # pragma: no cover - defensive guard
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": f"Internal error: {exc.__class__.__name__}: {exc}",
+                }
+            ),
+            500,
+        )
+
+    try:
+        with SessionLocal() as session:
+            defaults = session.execute(
+                select(ShiftPlanDefaults).where(
+                    ShiftPlanDefaults.year == year,
+                    ShiftPlanDefaults.month == month,
+                )
+            ).scalar_one_or_none()
+            return jsonify(_serialize_shift_defaults(defaults, year, month))
+    except Exception as exc:  # pragma: no cover - defensive guard
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": f"Internal error: {exc.__class__.__name__}: {exc}",
+                }
+            ),
+            500,
+        )
+
+
+@app.put("/api/shift-defaults")
+def upsert_shift_defaults():
+    data = request.get_json(silent=True) or {}
+    try:
+        year, month = _parse_year_month(data.get("year"), data.get("month"))
+    except ValueError as exc:
+        return {"error": str(exc)}, 400
+    except Exception as exc:  # pragma: no cover - defensive guard
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": f"Internal error: {exc.__class__.__name__}: {exc}",
+                }
+            ),
+            500,
+        )
+
+    fields = ["day_shifts", "night_shifts", "leader_shifts", "pgd_shifts"]
+    missing = [field for field in fields if field not in data]
+    if missing:
+        return {"error": f"Missing fields: {', '.join(missing)}"}, 400
+
+    validated: dict[str, int] = {}
+    for field in fields:
+        value = data.get(field)
+        if not isinstance(value, int):
+            return {"error": f"{field} must be an integer"}, 400
+        if value < 0:
+            return {"error": f"{field} must be >= 0"}, 400
+        validated[field] = value
+
+    try:
+        with SessionLocal() as session:
+            defaults = session.execute(
+                select(ShiftPlanDefaults).where(
+                    ShiftPlanDefaults.year == year,
+                    ShiftPlanDefaults.month == month,
+                )
+            ).scalar_one_or_none()
+
+            if defaults is None:
+                defaults = ShiftPlanDefaults(
+                    year=year,
+                    month=month,
+                    day_shifts=validated["day_shifts"],
+                    night_shifts=validated["night_shifts"],
+                    leader_shifts=validated["leader_shifts"],
+                    pgd_shifts=validated["pgd_shifts"],
+                )
+                session.add(defaults)
+            else:
+                for field, value in validated.items():
+                    setattr(defaults, field, value)
+
+            session.commit()
+            session.refresh(defaults)
+            return jsonify(_serialize_shift_defaults(defaults, year, month))
+    except Exception as exc:  # pragma: no cover - defensive guard
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": f"Internal error: {exc.__class__.__name__}: {exc}",
+                }
+            ),
             500,
         )
 

--- a/tests/test_shift_defaults_api.py
+++ b/tests/test_shift_defaults_api.py
@@ -1,0 +1,119 @@
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "shift_defaults.db"
+    monkeypatch.setenv("DB_URL", f"sqlite:///{db_path}")
+
+    import models
+    import app as app_module
+
+    importlib.reload(models)
+    models.init_db()
+    importlib.reload(app_module)
+
+    return SimpleNamespace(
+        client=app_module.app.test_client(),
+        models=models,
+    )
+
+
+def test_get_shift_defaults_returns_zero_when_absent(client):
+    app = client.client
+
+    res = app.get("/api/shift-defaults?year=2025&month=10")
+    assert res.status_code == 200
+    payload = res.get_json()
+
+    assert payload == {
+        "year": 2025,
+        "month": 10,
+        "day_shifts": 0,
+        "night_shifts": 0,
+        "leader_shifts": 0,
+        "pgd_shifts": 0,
+    }
+
+
+def test_put_and_get_shift_defaults(client):
+    app = client.client
+
+    res = app.put(
+        "/api/shift-defaults",
+        json={
+            "year": 2025,
+            "month": 10,
+            "day_shifts": 40,
+            "night_shifts": 20,
+            "leader_shifts": 8,
+            "pgd_shifts": 4,
+        },
+    )
+    assert res.status_code == 200
+    payload = res.get_json()
+    assert payload == {
+        "year": 2025,
+        "month": 10,
+        "day_shifts": 40,
+        "night_shifts": 20,
+        "leader_shifts": 8,
+        "pgd_shifts": 4,
+    }
+
+    res = app.get("/api/shift-defaults?year=2025&month=10")
+    assert res.status_code == 200
+    fetched = res.get_json()
+    assert fetched == payload
+
+
+def test_shift_defaults_validation_errors(client):
+    app = client.client
+
+    res = app.put(
+        "/api/shift-defaults",
+        json={
+            "year": 2025,
+            "month": 10,
+            "day_shifts": 10,
+            "night_shifts": 5,
+            "leader_shifts": 2,
+        },
+    )
+    assert res.status_code == 400
+    assert "Missing fields" in res.get_json()["error"]
+
+    res = app.put(
+        "/api/shift-defaults",
+        json={
+            "year": 2025,
+            "month": 10,
+            "day_shifts": 10,
+            "night_shifts": -1,
+            "leader_shifts": 2,
+            "pgd_shifts": 1,
+        },
+    )
+    assert res.status_code == 400
+    assert "night_shifts" in res.get_json()["error"]
+
+    res = app.put(
+        "/api/shift-defaults",
+        json={
+            "year": 2025,
+            "month": 10,
+            "day_shifts": 10,
+            "night_shifts": "5",
+            "leader_shifts": 2,
+            "pgd_shifts": 1,
+        },
+    )
+    assert res.status_code == 400
+    assert "night_shifts" in res.get_json()["error"]
+
+    res = app.get("/api/shift-defaults?year=2025&month=13")
+    assert res.status_code == 400
+    assert "month" in res.get_json()["error"]


### PR DESCRIPTION
## Summary
- add GET and PUT /api/shift-defaults endpoints backed by ShiftPlanDefaults
- ensure monthly targets require non-negative integers and serialize defaults
- add unit tests covering happy path retrieval and validation scenarios

## Testing
- pytest tests/test_shift_defaults_api.py

------
https://chatgpt.com/codex/tasks/task_e_68de7a51273083209e61246960e02d0e