### PR TITLE
feat: enforce schedule config prerequisites

### DIFF
--- a/app.py
+++ b/app.py
@@ -1312,11 +1312,74 @@ def gen():
     save_flag = bool(payload.get("save", False))
     fill_hc = bool(payload.get("fill_hc", False))
 
+    try:
+        with SessionLocal() as session:
+            month_config = session.execute(
+                select(MonthConfig).where(
+                    MonthConfig.year == year, MonthConfig.month == month
+                )
+            ).scalar_one_or_none()
+            shift_defaults = session.execute(
+                select(ShiftPlanDefaults).where(
+                    ShiftPlanDefaults.year == year,
+                    ShiftPlanDefaults.month == month,
+                )
+            ).scalar_one_or_none()
+
+            missing: dict[str, str] = {}
+            if month_config is None:
+                missing["month_config"] = (
+                    f"No month config found for {year}-{month:02d}"
+                )
+            if shift_defaults is None:
+                missing["shift_plan_defaults"] = (
+                    f"No shift plan defaults found for {year}-{month:02d}"
+                )
+            if missing:
+                return (
+                    jsonify(
+                        {
+                            "ok": False,
+                            "error": "Missing configuration",
+                            "missing": missing,
+                        }
+                    ),
+                    400,
+                )
+
+            config_payload = _build_month_config_payload(session, year, month)
+            effective_working_days = float(
+                config_payload.get("effective_working_days", 0.0)
+            )
+            shift_plan_defaults = {
+                "day_shifts": shift_defaults.day_shifts,
+                "night_shifts": shift_defaults.night_shifts,
+                "leader_shifts": shift_defaults.leader_shifts,
+                "pgd_shifts": shift_defaults.pgd_shifts,
+            }
+    except Exception as exc:  # pragma: no cover - defensive guard
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": f"Internal error: {exc.__class__.__name__}: {exc}",
+                }
+            ),
+            500,
+        )
+
     print("[API] generate begin", year, month, shuffle, seed, save_flag, fill_hc, flush=True)
 
     try:
         res = generate_schedule(
-            year, month, shuffle=shuffle, seed=seed, save=save_flag, fill_hc=fill_hc
+            year,
+            month,
+            shuffle=shuffle,
+            seed=seed,
+            save=save_flag,
+            fill_hc=fill_hc,
+            effective_working_days=effective_working_days,
+            shift_plan_defaults=shift_plan_defaults,
         )
         print("[API] generate end", type(res), flush=True)
         # engine may return a dict or (dict, status)

--- a/scheduler/engine/core.py
+++ b/scheduler/engine/core.py
@@ -55,6 +55,10 @@ class Context:
     save: bool
     session: Session
 
+    # ===== cấu hình tháng
+    working_day_target: float | None = None
+    shift_plan_defaults: Dict[str, int] = field(default_factory=dict)
+
     # ===== accumulators
     credit_map: DefaultDict[int, float] = field(default_factory=lambda: defaultdict(float))
     _planned: List[Planned] = field(default_factory=list)
@@ -81,7 +85,14 @@ class Context:
 
 
 def build_context(
-    *, year: int, month: int, shuffle: bool, seed: Optional[int], save: bool
+    *,
+    year: int,
+    month: int,
+    shuffle: bool,
+    seed: Optional[int],
+    save: bool,
+    working_day_target: float | None = None,
+    shift_plan_defaults: dict[str, int] | None = None,
 ) -> Tuple[Context, date, date]:
     """Tạo ngữ cảnh chạy cho cả tháng + trả về (first, last)."""
     first = ymd(year, month, 1)
@@ -130,6 +141,8 @@ def build_context(
         fixed=fixed,
         holidays=holidays,
         base_quota=base_quota,
+        working_day_target=working_day_target,
+        shift_plan_defaults=dict(shift_plan_defaults or {}),
         rng=rng,
         save=save,
         session=s,

--- a/scheduler/engine/engine.py
+++ b/scheduler/engine/engine.py
@@ -25,13 +25,23 @@ def schedule_month(
     seed: Optional[int] = None,
     save: bool = False,
     fill_hc: bool = False,
+    effective_working_days: float | None = None,
+    shift_plan_defaults: dict[str, int] | None = None,
 ):
     print(
         f"[ENGINE] start y={year} m={month} shuffle={shuffle} seed={seed} save={save} fill_hc={fill_hc}"
     )
     reset_trackers()
 
-    ctx, first, last = build_context(year=year, month=month, shuffle=shuffle, seed=seed, save=save)
+    ctx, first, last = build_context(
+        year=year,
+        month=month,
+        shuffle=shuffle,
+        seed=seed,
+        save=save,
+        working_day_target=effective_working_days,
+        shift_plan_defaults=shift_plan_defaults,
+    )
     # build rank map for fairness
     rank_map = {st.id: 1 for st in ctx.GDV1}
     rank_map.update({st.id: 1 for st in ctx.TC})

--- a/tests/test_holiday_api.py
+++ b/tests/test_holiday_api.py
@@ -168,6 +168,48 @@ def test_import_holidays_from_nager(client, monkeypatch):
     assert len(rows) == 3
 
 
+def test_import_year_holidays_matches_count(client, monkeypatch):
+    app = client.client
+    module = client.module
+
+    incoming = [
+        {
+            "day": date(2027, 1, 1),
+            "name": "New Year",
+            "kind": "Public",
+            "official": True,
+            "source": "nager",
+        },
+        {
+            "day": date(2027, 4, 30),
+            "name": "Liberation Day",
+            "kind": "Public",
+            "official": True,
+            "source": "nager",
+        },
+        {
+            "day": date(2027, 5, 1),
+            "name": "Labour Day",
+            "kind": "Public",
+            "official": True,
+            "source": "nager",
+        },
+    ]
+
+    monkeypatch.setattr(module, "_fetch_nager_holidays", lambda year: incoming)
+
+    res = app.post("/api/holidays/import?year=2027&source=nager")
+    assert res.status_code == 200
+    payload = res.get_json()
+    assert payload["inserted"] == len(incoming)
+
+    res = app.get("/api/holidays?year=2027")
+    assert res.status_code == 200
+    rows = res.get_json()
+    assert len(rows) == len(incoming)
+    assert {row["day"] for row in rows} == {item["day"].isoformat() for item in incoming}
+
+
 def test_fetch_nager_holidays(monkeypatch):
     import app as app_module
 

--- a/tests/test_schedule_generate_api.py
+++ b/tests/test_schedule_generate_api.py
@@ -1,0 +1,121 @@
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "generate.db"
+    monkeypatch.setenv("DB_URL", f"sqlite:///{db_path}")
+
+    import models
+    import app as app_module
+
+    importlib.reload(models)
+    models.init_db()
+    importlib.reload(app_module)
+
+    return SimpleNamespace(
+        client=app_module.app.test_client(),
+        models=models,
+        module=app_module,
+    )
+
+
+def test_generate_requires_month_and_shift_config(client, monkeypatch):
+    app = client.client
+    module = client.module
+
+    def fail(*args, **kwargs):  # pragma: no cover - defensive guard
+        raise AssertionError("engine should not be invoked when config missing")
+
+    monkeypatch.setattr(module, "generate_schedule", fail)
+
+    res = app.post("/api/schedule/generate", json={"year": 2025, "month": 5})
+    assert res.status_code == 400
+    payload = res.get_json()
+    assert payload["error"] == "Missing configuration"
+    assert "month_config" in payload["missing"]
+    assert "shift_plan_defaults" in payload["missing"]
+
+
+
+def test_generate_requires_shift_defaults_only(client):
+    app = client.client
+    models = client.models
+
+    with models.SessionLocal() as session:
+        session.add(models.MonthConfig(year=2025, month=5))
+        session.commit()
+
+    res = app.post("/api/schedule/generate", json={"year": 2025, "month": 5})
+    assert res.status_code == 400
+    payload = res.get_json()
+    assert "shift_plan_defaults" in payload["missing"]
+    assert "month_config" not in payload["missing"]
+
+
+
+def test_generate_passes_config_to_engine(client, monkeypatch):
+    app = client.client
+    models = client.models
+    module = client.module
+
+    with models.SessionLocal() as session:
+        session.add(
+            models.MonthConfig(
+                year=2025,
+                month=6,
+                weekend_policy=models.WeekendPolicy.SAT_WORK_AM,
+                extra_workdays=["2025-06-22"],
+                extra_offdays=["2025-06-29"],
+            )
+        )
+        session.add(
+            models.ShiftPlanDefaults(
+                year=2025,
+                month=6,
+                day_shifts=40,
+                night_shifts=20,
+                leader_shifts=10,
+                pgd_shifts=5,
+            )
+        )
+        session.commit()
+
+    with models.SessionLocal() as session:
+        config_payload = module._build_month_config_payload(session, 2025, 6)
+    expected_working_days = float(config_payload["effective_working_days"])
+
+    captured = {}
+
+    def fake_schedule(year, month, **kwargs):
+        captured["args"] = (year, month)
+        captured["kwargs"] = kwargs
+        return {"ok": True, "planned": []}
+
+    monkeypatch.setattr(module, "generate_schedule", fake_schedule)
+
+    res = app.post(
+        "/api/schedule/generate",
+        json={"year": 2025, "month": 6, "shuffle": True, "seed": 123},
+    )
+    assert res.status_code == 200
+    assert res.get_json()["ok"] is True
+
+    assert captured["args"] == (2025, 6)
+    kwargs = captured["kwargs"]
+    assert kwargs["shuffle"] is True
+    assert kwargs["seed"] == 123
+    assert kwargs["save"] is False
+    assert kwargs["fill_hc"] is False
+
+    expected_defaults = {
+        "day_shifts": 40,
+        "night_shifts": 20,
+        "leader_shifts": 10,
+        "pgd_shifts": 5,
+    }
+    assert kwargs["shift_plan_defaults"] == expected_defaults
+    assert kwargs["effective_working_days"] == pytest.approx(expected_working_days)


### PR DESCRIPTION
## Summary
- require month configuration and shift plan defaults before generating schedules and surface detailed 400 errors
- pass effective working days and stored shift defaults through to the engine context
- add coverage for holiday imports and schedule generation configuration handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de7e7789548320868f6f45c31643bb