### PR TITLE
Add metrics APIs and CSV exports for dashboard reporting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,11 @@ Added department management and custom shift configuration to support multiple d
 - Exercise both happy-path & quota edge cases (locked staff, fixed Đ@TD, fairness 7-day window)
 - `backend/tests/test_export_month_csv.py` must assert CSV has non‑empty rows
 
+## Metrics & Reports
+- Dashboard metrics live under `/api/metrics/*` (staff workload, department compare, attendance stub, cost).
+- CSV exports for metrics are exposed at `/api/reports/*.csv`; reuse helpers to keep headers consistent.
+- `LABOR_COST_PER_HOUR` controls cost metric; defaults to 0 when unset. Update docs if you change this contract.
+
 ## Schedule Generation Flow
 
 ### Pre-requisites (Configuration Phase)

--- a/api/constants.py
+++ b/api/constants.py
@@ -1,0 +1,19 @@
+"""Shared constants for API calculations."""
+from __future__ import annotations
+
+BASE_HOURS_PER_CREDIT = 8.0
+
+SHIFT_CREDIT = {
+    "CA1": 1,
+    "CA2": 1,
+    "K": 1.25,
+    "Đ": 1.5,
+    "HC": 1,
+    "P": 0,
+}
+
+SHIFT_HOURS = {code: credit * BASE_HOURS_PER_CREDIT for code, credit in SHIFT_CREDIT.items()}
+
+NIGHT_SHIFT_CODES = {"Đ"}
+
+DEFAULT_MAX_HOURS_PER_STAFF = 208.0

--- a/api/export_month_csv.py
+++ b/api/export_month_csv.py
@@ -7,17 +7,9 @@ from typing import Optional
 
 from flask import Response, stream_with_context
 
-from models import Assignment, SessionLocal, Staff
+import models
 
-# Map shift code to credit value
-SHIFT_CREDIT = {
-    "CA1": 1,
-    "CA2": 1,
-    "K": 1.25,
-    "Đ": 1.5,
-    "HC": 1,
-    "P": 0,
-}
+from .constants import SHIFT_CREDIT
 
 _RANK_RE = re.compile(r"\[RANK:(1|2)\]")
 
@@ -39,19 +31,19 @@ def export_month_csv(year: int, month: int) -> Response:
     start = date(year, month, 1)
     end = date(year, month, last_day)
 
-    with SessionLocal() as s:
+    with models.SessionLocal() as s:
         rows = (
             s.query(
-                Assignment.day,
-                Staff.full_name,
-                Staff.role,
-                Staff.notes,
-                Assignment.shift_code,
-                Assignment.position,
+                models.Assignment.day,
+                models.Staff.full_name,
+                models.Staff.role,
+                models.Staff.notes,
+                models.Assignment.shift_code,
+                models.Assignment.position,
             )
-            .join(Staff, Assignment.staff_id == Staff.id)
-            .filter(Assignment.day.between(start, end))
-            .order_by(Assignment.day, Assignment.staff_id)
+            .join(models.Staff, models.Assignment.staff_id == models.Staff.id)
+            .filter(models.Assignment.day.between(start, end))
+            .order_by(models.Assignment.day, models.Assignment.staff_id)
             .all()
         )
 

--- a/api/metrics.py
+++ b/api/metrics.py
@@ -1,0 +1,148 @@
+"""Metrics helpers for dashboard endpoints."""
+from __future__ import annotations
+
+import calendar
+from dataclasses import dataclass
+from datetime import date
+from typing import Iterable, Sequence
+
+from sqlalchemy import case, func
+
+import models
+
+from .constants import DEFAULT_MAX_HOURS_PER_STAFF, NIGHT_SHIFT_CODES, SHIFT_HOURS
+
+
+@dataclass(frozen=True)
+class StaffWorkloadRow:
+    staff_id: int
+    name: str
+    hours: float
+    night_hours: float
+
+
+@dataclass(frozen=True)
+class DepartmentWorkloadRow:
+    department_id: int
+    dept: str
+    staff_count: int
+    hours: float
+    overtime_hours: float
+
+
+def _month_range(year: int, month: int) -> tuple[date, date]:
+    last_day = calendar.monthrange(year, month)[1]
+    start = date(year, month, 1)
+    end = date(year, month, last_day)
+    return start, end
+
+
+def _hours_case():
+    whens: Sequence[tuple[object, float]] = [
+        (models.Assignment.shift_code == code, hours)
+        for code, hours in SHIFT_HOURS.items()
+    ]
+    return case(*whens, else_=0.0)
+
+
+def _night_hours_case():
+    whens: Sequence[tuple[object, float]] = [
+        (models.Assignment.shift_code == code, SHIFT_HOURS[code])
+        for code in NIGHT_SHIFT_CODES
+    ]
+    return case(*whens, else_=0.0)
+
+
+def load_staff_workload(year: int, month: int) -> tuple[list[StaffWorkloadRow], dict[str, float]]:
+    """Return per-staff workload with totals for a month."""
+
+    start, end = _month_range(year, month)
+    hour_case = _hours_case()
+    night_case = _night_hours_case()
+
+    with models.SessionLocal() as session:
+        rows: Iterable[tuple[int, str, float, float]] = (
+            session.query(
+                models.Assignment.staff_id,
+                models.Staff.full_name,
+                func.sum(hour_case).label("hours"),
+                func.sum(night_case).label("night_hours"),
+            )
+            .join(models.Staff, models.Assignment.staff_id == models.Staff.id)
+            .filter(models.Assignment.day.between(start, end))
+            .group_by(models.Assignment.staff_id, models.Staff.full_name)
+            .order_by(func.sum(hour_case).desc(), models.Staff.full_name)
+            .all()
+        )
+
+    data = [
+        StaffWorkloadRow(
+            staff_id=row[0],
+            name=row[1],
+            hours=float(row[2] or 0.0),
+            night_hours=float(row[3] or 0.0),
+        )
+        for row in rows
+    ]
+    totals = {
+        "hours": sum(item.hours for item in data),
+        "night_hours": sum(item.night_hours for item in data),
+    }
+    return data, totals
+
+
+def load_department_comparison(year: int, month: int) -> list[DepartmentWorkloadRow]:
+    """Return workload aggregated per department for a month."""
+
+    start, end = _month_range(year, month)
+    hour_case = _hours_case()
+
+    with models.SessionLocal() as session:
+        departments = session.query(models.Department).order_by(models.Department.name).all()
+        staff_counts = {
+            dept_id: count
+            for dept_id, count in (
+                session.query(
+                    models.Department.id,
+                    func.count(models.Staff.id).label("staff_count"),
+                )
+                .outerjoin(models.Staff, models.Staff.department_id == models.Department.id)
+                .group_by(models.Department.id)
+                .all()
+            )
+        }
+        hour_map = {
+            dept_id: float(hours or 0.0)
+            for dept_id, hours in (
+                session.query(
+                    models.Department.id,
+                    func.sum(hour_case).label("hours"),
+                )
+                .join(models.Staff, models.Staff.department_id == models.Department.id)
+                .join(models.Assignment, models.Assignment.staff_id == models.Staff.id)
+                .filter(models.Assignment.day.between(start, end))
+                .group_by(models.Department.id)
+                .all()
+            )
+        }
+
+    result: list[DepartmentWorkloadRow] = []
+    for dept in departments:
+        staff_count = int(staff_counts.get(dept.id, 0) or 0)
+        hours = hour_map.get(dept.id, 0.0)
+        settings = dept.settings or {}
+        max_hours_per_staff = settings.get("max_hours_per_month") if isinstance(settings, dict) else None
+        if not isinstance(max_hours_per_staff, (int, float)):
+            max_hours_per_staff = DEFAULT_MAX_HOURS_PER_STAFF
+        overtime_limit = staff_count * float(max_hours_per_staff)
+        overtime_hours = max(hours - overtime_limit, 0.0)
+        result.append(
+            DepartmentWorkloadRow(
+                department_id=dept.id,
+                dept=dept.name,
+                staff_count=staff_count,
+                hours=hours,
+                overtime_hours=overtime_hours,
+            )
+        )
+    return result

--- a/app.py
+++ b/app.py
@@ -18,6 +18,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from api.export_month_csv import export_month_csv as _export_month_csv
+from api.metrics import load_department_comparison, load_staff_workload
 from models import (
     Assignment,
     Department,
@@ -147,6 +148,36 @@ def _parse_year_month(year_raw, month_raw) -> tuple[int, int]:
     if year < 1900 or year > 2100:
         raise ValueError("year must be between 1900 and 2100")
     return year, month
+
+
+def _get_cost_per_hour() -> float:
+    raw = os.getenv("LABOR_COST_PER_HOUR", "0").strip()
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _build_csv_response(filename: str, header: list[str], rows: list[list[object]]):
+    def generate():
+        buf = io.StringIO()
+        writer = csv.writer(buf)
+        writer.writerow(header)
+        yield buf.getvalue()
+        buf.seek(0)
+        buf.truncate(0)
+        for row in rows:
+            writer.writerow(row)
+            yield buf.getvalue()
+            buf.seek(0)
+            buf.truncate(0)
+
+    response = Response(
+        stream_with_context(generate()),
+        content_type="text/csv; charset=utf-8",
+    )
+    response.headers["Content-Disposition"] = f"attachment; filename={filename}"
+    return response
 
 
 def _coerce_extra_dates(
@@ -1564,6 +1595,155 @@ def export_month_csv_endpoint():
     if m < 1 or m > 12:
         return {"error": "month must be 1..12"}, 400
     return _export_month_csv(y, m)
+
+
+@app.get("/api/metrics/staff-workload")
+def metrics_staff_workload():
+    try:
+        year, month = _parse_year_month(
+            request.args.get("year"), request.args.get("month")
+        )
+    except ValueError as exc:
+        return {"error": str(exc)}, 400
+
+    data, totals = load_staff_workload(year, month)
+    return jsonify(
+        {
+            "by_staff": [
+                {
+                    "staff_id": row.staff_id,
+                    "name": row.name,
+                    "hours": row.hours,
+                    "night_hours": row.night_hours,
+                }
+                for row in data
+            ],
+            "totals": totals,
+        }
+    )
+
+
+@app.get("/api/metrics/department-compare")
+def metrics_department_compare():
+    try:
+        year, month = _parse_year_month(
+            request.args.get("year"), request.args.get("month")
+        )
+    except ValueError as exc:
+        return {"error": str(exc)}, 400
+
+    rows = load_department_comparison(year, month)
+    return jsonify(
+        {
+            "by_department": [
+                {
+                    "dept": row.dept,
+                    "staff_count": row.staff_count,
+                    "hours": row.hours,
+                    "overtime_hours": row.overtime_hours,
+                }
+                for row in rows
+            ]
+        }
+    )
+
+
+@app.get("/api/metrics/attendance")
+def metrics_attendance():
+    start_raw = request.args.get("from")
+    end_raw = request.args.get("to")
+    if not start_raw or not end_raw:
+        return {"error": "from and to required"}, 400
+
+    try:
+        start = date.fromisoformat(start_raw)
+        end = date.fromisoformat(end_raw)
+    except ValueError:
+        return {"error": "from/to must be YYYY-MM-DD"}, 400
+
+    if end < start:
+        return {"error": "to must be on or after from"}, 400
+
+    return jsonify({"rate": 0, "absences": [], "late": []})
+
+
+@app.get("/api/metrics/cost")
+def metrics_cost():
+    try:
+        year, month = _parse_year_month(
+            request.args.get("year"), request.args.get("month")
+        )
+    except ValueError as exc:
+        return {"error": str(exc)}, 400
+
+    _, totals = load_staff_workload(year, month)
+    cost = totals["hours"] * _get_cost_per_hour()
+    return jsonify({"labor_cost": cost})
+
+
+@app.get("/api/reports/staff-workload.csv")
+def export_staff_workload_csv():
+    try:
+        year, month = _parse_year_month(
+            request.args.get("year"), request.args.get("month")
+        )
+    except ValueError as exc:
+        return {"error": str(exc)}, 400
+
+    data, totals = load_staff_workload(year, month)
+    rows = [
+        [row.staff_id, row.name, f"{row.hours:.2f}", f"{row.night_hours:.2f}"]
+        for row in data
+    ]
+    if data:
+        rows.append(["TOTAL", "", f"{totals['hours']:.2f}", f"{totals['night_hours']:.2f}"])
+    return _build_csv_response(
+        f"staff-workload-{year:04d}-{month:02d}.csv",
+        ["staff_id", "name", "hours", "night_hours"],
+        rows,
+    )
+
+
+@app.get("/api/reports/department-compare.csv")
+def export_department_compare_csv():
+    try:
+        year, month = _parse_year_month(
+            request.args.get("year"), request.args.get("month")
+        )
+    except ValueError as exc:
+        return {"error": str(exc)}, 400
+
+    rows = load_department_comparison(year, month)
+    csv_rows = [
+        [
+            row.dept,
+            row.staff_count,
+            f"{row.hours:.2f}",
+            f"{row.overtime_hours:.2f}",
+        ]
+        for row in rows
+    ]
+    return _build_csv_response(
+        f"department-compare-{year:04d}-{month:02d}.csv",
+        ["department", "staff_count", "hours", "overtime_hours"],
+        csv_rows,
+    )
+
+
+@app.get("/api/reports/schedule-month.csv")
+def export_schedule_month_csv():
+    try:
+        year, month = _parse_year_month(
+            request.args.get("year"), request.args.get("month")
+        )
+    except ValueError as exc:
+        return {"error": str(exc)}, 400
+
+    response = _export_month_csv(year, month)
+    response.headers["Content-Disposition"] = (
+        f"attachment; filename=schedule-month-{year:04d}-{month:02d}.csv"
+    )
+    return response
 
 
 @app.get("/api/rules/expected")

--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -1,0 +1,187 @@
+import csv
+import importlib
+from datetime import date
+from io import StringIO
+
+import pytest
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("LABOR_COST_PER_HOUR", "50")
+    import models
+    import api.metrics as metrics_module
+
+    importlib.reload(models)
+    models.init_db()
+    importlib.reload(metrics_module)
+
+    import app as app_module
+
+    importlib.reload(app_module)
+    return app_module.app.test_client(), models
+
+
+@pytest.fixture()
+def sample_data(client):
+    app, models = client
+    with models.SessionLocal() as session:
+        dept_a = models.Department(
+            name="Support",
+            code="SUP",
+            color="#fff",
+            icon="Headphones",
+            settings={"max_hours_per_month": 14},
+        )
+        dept_b = models.Department(
+            name="Sales",
+            code="SAL",
+            color="#000",
+            icon="Briefcase",
+        )
+        session.add_all([dept_a, dept_b])
+        session.flush()
+
+        staff_1 = models.Staff(
+            full_name="Alice",
+            role="TC",
+            department_id=dept_a.id,
+        )
+        staff_2 = models.Staff(
+            full_name="Bob",
+            role="TC",
+            department_id=dept_a.id,
+        )
+        staff_3 = models.Staff(
+            full_name="Carol",
+            role="GDV",
+            department_id=dept_b.id,
+        )
+        session.add_all([staff_1, staff_2, staff_3])
+        session.flush()
+
+        assignments = [
+            models.Assignment(
+                staff_id=staff_1.id,
+                day=date(2024, 9, 1),
+                shift_code="CA1",
+                position="TD",
+            ),
+            models.Assignment(
+                staff_id=staff_1.id,
+                day=date(2024, 9, 2),
+                shift_code="Đ",
+                position="TD",
+            ),
+            models.Assignment(
+                staff_id=staff_2.id,
+                day=date(2024, 9, 1),
+                shift_code="K",
+                position="TD",
+            ),
+            models.Assignment(
+                staff_id=staff_3.id,
+                day=date(2024, 9, 3),
+                shift_code="CA2",
+                position="PGD",
+            ),
+            models.Assignment(
+                staff_id=staff_3.id,
+                day=date(2024, 8, 30),
+                shift_code="CA2",
+                position="PGD",
+            ),
+        ]
+        session.add_all(assignments)
+        session.commit()
+    return app, models
+
+
+def _decode_csv(response):
+    text = response.data.decode("utf-8")
+    reader = csv.reader(StringIO(text))
+    return list(reader)
+
+
+def test_metrics_staff_workload(client, sample_data):
+    app, _ = sample_data
+    res = app.get("/api/metrics/staff-workload?year=2024&month=9")
+    assert res.status_code == 200
+    body = res.get_json()
+    assert body["totals"] == {"hours": pytest.approx(38.0), "night_hours": pytest.approx(12.0)}
+    assert body["by_staff"][0]["name"] == "Alice"
+    assert body["by_staff"][0]["hours"] == pytest.approx(20.0)
+    assert body["by_staff"][0]["night_hours"] == pytest.approx(12.0)
+    assert len(body["by_staff"]) == 3
+
+
+def test_metrics_staff_workload_missing_params(client, sample_data):
+    app, _ = sample_data
+    res = app.get("/api/metrics/staff-workload?year=2024")
+    assert res.status_code == 400
+    assert res.get_json()["error"]
+
+
+def test_metrics_department_compare(client, sample_data):
+    app, _ = sample_data
+    res = app.get("/api/metrics/department-compare?year=2024&month=9")
+    assert res.status_code == 200
+    body = res.get_json()
+    departments = {item["dept"]: item for item in body["by_department"]}
+    assert departments["Support"]["staff_count"] == 2
+    assert departments["Support"]["hours"] == pytest.approx(30.0)
+    assert departments["Support"]["overtime_hours"] == pytest.approx(2.0)
+    assert departments["Sales"]["hours"] == pytest.approx(8.0)
+
+
+def test_metrics_attendance_validation(client, sample_data):
+    app, _ = sample_data
+    res = app.get("/api/metrics/attendance")
+    assert res.status_code == 400
+    res = app.get("/api/metrics/attendance?from=2024-09-05&to=bad")
+    assert res.status_code == 400
+    res = app.get("/api/metrics/attendance?from=2024-09-05&to=2024-09-04")
+    assert res.status_code == 400
+    res = app.get("/api/metrics/attendance?from=2024-09-01&to=2024-09-30")
+    assert res.status_code == 200
+    assert res.get_json() == {"rate": 0, "absences": [], "late": []}
+
+
+def test_metrics_cost_uses_env(client, sample_data, monkeypatch):
+    app, _ = sample_data
+    monkeypatch.setenv("LABOR_COST_PER_HOUR", "100")
+    res = app.get("/api/metrics/cost?year=2024&month=9")
+    assert res.status_code == 200
+    assert res.get_json()["labor_cost"] == pytest.approx(3800.0)
+
+
+def test_reports_staff_workload_csv(client, sample_data):
+    app, _ = sample_data
+    res = app.get("/api/reports/staff-workload.csv?year=2024&month=9")
+    assert res.status_code == 200
+    rows = _decode_csv(res)
+    assert rows[0] == ["staff_id", "name", "hours", "night_hours"]
+    assert any(row[1] == "Alice" for row in rows[1:])
+    assert "staff-workload-2024-09" in res.headers["Content-Disposition"]
+
+
+def test_reports_department_compare_csv(client, sample_data):
+    app, _ = sample_data
+    res = app.get("/api/reports/department-compare.csv?year=2024&month=9")
+    assert res.status_code == 200
+    rows = _decode_csv(res)
+    assert rows[0] == ["department", "staff_count", "hours", "overtime_hours"]
+    assert len(rows) >= 2
+    assert "department-compare-2024-09" in res.headers["Content-Disposition"]
+
+
+def test_reports_schedule_month_csv_wrapper(client, sample_data):
+    app, _ = sample_data
+    res = app.get("/api/reports/schedule-month.csv?year=2024&month=9")
+    assert res.status_code == 200
+    rows = _decode_csv(res)
+    assert rows[0] == ["Ngày", "Staff", "Role", "Rank", "Shift", "Position", "Công"]
+    assert len(rows) > 1
+    assert "schedule-month-2024-09" in res.headers["Content-Disposition"]


### PR DESCRIPTION
## Summary
- add shared shift constants and aggregation helpers for dashboard metrics
- expose metrics JSON endpoints and CSV report downloads, reusing month export helpers
- document the new APIs and cover them with regression tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfd68d99a48320bc64116aaf80715c