### PR TITLE
feat: add department schedule reporting apis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,11 @@ SQLite via SQLAlchemy; migrations via `make migrate`. Models: `Staff`, `Assignme
 
 ## Phase 1 & 2: Multi-Department Support (COMPLETED)
 
+## Phase 3: Schedule Reporting (IN PROGRESS)
+
+- 2024-05-07: Added department-active listing plus schedule reporting APIs (`GET /api/departments?active=1`, `/api/schedule`, `/api/schedule/overview`) with unit tests for filtering, counts, and coverage summaries.
+
+
 ### Overview
 Added department management and custom shift configuration to support multiple departments with different shift requirements.
 

--- a/APIs.md
+++ b/APIs.md
@@ -10,7 +10,7 @@ All routes are rooted at `http://localhost:8000`. Unless noted otherwise respons
 - `GET /api/rules/expected` — expected staffing counts for the selected month (`year`, `month` query params)
 
 ## Staff
-- `GET /api/staff` — list staff records
+- `GET /api/staff` — list staff records (supports `department_id`, `role`, `q` filters)
 - `POST /api/staff` — create staff (`full_name`, `role`, `can_night`, `base_quota`, `notes`)
 - `DELETE /api/staff/{id}` — remove staff
 
@@ -33,7 +33,9 @@ All routes are rooted at `http://localhost:8000`. Unless noted otherwise respons
 - `DELETE /api/holidays/{id}` — delete holiday
 - `POST /api/holidays/import?year=YYYY&source=nager` — import official VN holidays from Nager.Date
 
-## Schedule and assignments
+- `GET /api/departments` — list departments (use `active=1` for active subset)
+- `GET /api/schedule` — list assignments for the month (`year`, `month`, optional `department_id`)
+- `GET /api/schedule/overview` — aggregated coverage by department (`year`, `month`)
 - `GET /api/assignments` — list generated assignments for the month (`year`, `month`)
 - `GET /api/schedule/validate` — validate current schedule data for the month
 - `GET /api/schedule/estimate` — estimator for staffing expectations

--- a/app.py
+++ b/app.py
@@ -7,11 +7,13 @@ import os
 import pathlib
 import urllib.error
 import urllib.request
+from collections import defaultdict
 from datetime import date, timedelta
 
 from flask import Flask, Response, jsonify, request, send_from_directory, stream_with_context
 from flask_cors import CORS
-from sqlalchemy import select, text
+from sqlalchemy import func, select, text
+from sqlalchemy.orm import selectinload
 
 from dotenv import load_dotenv
 
@@ -374,10 +376,38 @@ def ping():
 @app.get("/api/departments")
 def list_departments():
     """Get all departments."""
+
+    active_raw = request.args.get("active")
+    active_filter: bool | None = None
+    if active_raw is not None:
+        raw = active_raw.strip().lower()
+        if raw in {"1", "true", "yes"}:
+            active_filter = True
+        elif raw in {"0", "false", "no"}:
+            active_filter = False
+        else:
+            return jsonify({"error": "active must be truthy (1/true) or falsy (0/false)"}), 400
+
     with SessionLocal() as s:
-        rows = s.execute(select(Department).order_by(Department.name)).scalars().all()
-        return jsonify(
-            [
+        query = select(Department).order_by(Department.name)
+        if active_filter is not None:
+            query = query.where(Department.is_active.is_(active_filter))
+        rows = s.execute(query).scalars().all()
+
+        if active_filter is not None:
+            payload = [
+                {
+                    "id": r.id,
+                    "name": r.name,
+                    "code": r.code,
+                    "color": r.color,
+                    "icon": r.icon,
+                    "settings": r.settings,
+                }
+                for r in rows
+            ]
+        else:
+            payload = [
                 {
                     "id": r.id,
                     "name": r.name,
@@ -392,7 +422,8 @@ def list_departments():
                 }
                 for r in rows
             ]
-        )
+
+        return jsonify(payload)
 
 
 @app.post("/api/departments")
@@ -690,12 +721,25 @@ def shifts():
 def list_staff():
     """Get all staff, optionally filtered by department."""
     dept_id = request.args.get("department_id", type=int)
+    role_filter_raw = request.args.get("role")
+    query_raw = request.args.get("q", "").strip()
 
     with SessionLocal() as s:
-        query = select(Staff)
+        query = select(Staff).options(selectinload(Staff.department))
 
-        if dept_id:
+        if dept_id is not None:
             query = query.where(Staff.department_id == dept_id)
+
+        if role_filter_raw:
+            roles = {item.strip().upper() for item in role_filter_raw.split(",") if item.strip()}
+            if roles:
+                query = query.where(func.upper(Staff.role).in_(sorted(roles)))
+
+        if query_raw:
+            pattern = f"%{query_raw.lower()}%"
+            query = query.where(func.lower(Staff.full_name).like(pattern))
+
+        query = query.order_by(func.lower(Staff.full_name))
 
         rows = s.execute(query).scalars().all()
         return jsonify(
@@ -713,6 +757,165 @@ def list_staff():
                 for r in rows
             ]
         )
+
+
+def _month_range(year: int, month: int) -> tuple[date, date]:
+    last_day = month_last_day(year, month)
+    start = date(year, month, 1)
+    end = date(year, month, last_day)
+    return start, end
+
+
+@app.get("/api/schedule")
+def get_schedule():
+    """Return assignments for a month with optional department filtering."""
+
+    try:
+        year, month = _parse_year_month(request.args.get("year"), request.args.get("month"))
+    except ValueError as exc:
+        return {"error": str(exc)}, 400
+
+    dept_id = request.args.get("department_id", type=int)
+    start, end = _month_range(year, month)
+
+    with SessionLocal() as s:
+        if dept_id is not None:
+            dept = s.get(Department, dept_id)
+            if not dept or not dept.is_active:
+                return {"error": "Department not found or inactive"}, 404
+
+        query = (
+            select(
+                Assignment.day,
+                Assignment.shift_code,
+                Assignment.position,
+                Assignment.staff_id,
+                Staff.full_name,
+                Staff.role,
+                Staff.department_id,
+                Department.name,
+            )
+            .join(Staff, Assignment.staff_id == Staff.id, isouter=True)
+            .join(Department, Staff.department_id == Department.id, isouter=True)
+            .where(Assignment.day.between(start, end))
+            .order_by(Assignment.day, Assignment.shift_code, Assignment.id)
+        )
+
+        if dept_id is not None:
+            query = query.where(Staff.department_id == dept_id)
+
+        rows = s.execute(query).all()
+
+    items: list[dict] = []
+    counts: dict[str, object] = {
+        "total": 0,
+        "by_shift": defaultdict(int),
+        "leaders": {"day": 0, "night": 0},
+    }
+
+    for day, shift_code, position, staff_id, full_name, role, row_dept_id, dept_name in rows:
+        items.append(
+            {
+                "day": day.isoformat(),
+                "shift_code": shift_code,
+                "position": position,
+                "staff_id": staff_id,
+                "staff_name": full_name,
+                "role": role,
+                "department_id": row_dept_id,
+                "department_name": dept_name,
+            }
+        )
+        counts["total"] += 1
+        counts["by_shift"][shift_code] += 1
+        if shift_code == "K" and (position or "").upper() == "TD":
+            counts["leaders"]["day"] += 1
+        if shift_code == "Đ" and (position or "").upper() == "TD":
+            counts["leaders"]["night"] += 1
+
+    counts["by_shift"] = dict(counts["by_shift"])
+
+    return jsonify({"items": items, "counts": counts})
+
+
+@app.get("/api/schedule/overview")
+def schedule_overview():
+    """Summarise schedule coverage per department for a month."""
+
+    try:
+        year, month = _parse_year_month(request.args.get("year"), request.args.get("month"))
+    except ValueError as exc:
+        return {"error": str(exc)}, 400
+
+    start, end = _month_range(year, month)
+    days_in_month = month_last_day(year, month)
+
+    with SessionLocal() as s:
+        departments = (
+            s.execute(select(Department).order_by(Department.name)).scalars().all()
+        )
+        rows = s.execute(
+            select(
+                Assignment.day,
+                Assignment.shift_code,
+                Assignment.position,
+                Staff.department_id,
+                Department.name,
+                Department.is_active,
+            )
+            .join(Staff, Assignment.staff_id == Staff.id, isouter=True)
+            .join(Department, Staff.department_id == Department.id, isouter=True)
+            .where(Assignment.day.between(start, end))
+        ).all()
+
+    overview: dict[int, dict[str, object]] = {}
+    day_presence: dict[int, set[date]] = defaultdict(set)
+    day_shifts: dict[int, dict[str, set[date]]] = defaultdict(lambda: {"day": set(), "night": set()})
+    leader_flags: dict[int, dict[str, set[date]]] = defaultdict(lambda: {"day": set(), "night": set()})
+
+    for dept in departments:
+        if not dept.is_active:
+            continue
+        overview[dept.id] = {
+            "department_id": dept.id,
+            "name": dept.name,
+            "shifts": 0,
+            "missing_leaders": 0,
+            "coverage_rate": 0.0,
+        }
+
+    for day, shift_code, position, dept_id, dept_name, is_active in rows:
+        if dept_id is None or dept_id not in overview:
+            continue
+        info = overview[dept_id]
+        info["shifts"] += 1
+        day_presence[dept_id].add(day)
+        if shift_code == "K":
+            day_shifts[dept_id]["day"].add(day)
+            if (position or "").upper() == "TD":
+                leader_flags[dept_id]["day"].add(day)
+        elif shift_code == "Đ":
+            day_shifts[dept_id]["night"].add(day)
+            if (position or "").upper() == "TD":
+                leader_flags[dept_id]["night"].add(day)
+
+    for dept_id, info in overview.items():
+        covered_days = len(day_presence.get(dept_id, set()))
+        info["coverage_rate"] = round(
+            covered_days / days_in_month if days_in_month else 0.0,
+            4,
+        )
+
+        missing = 0
+        for bucket in ("day", "night"):
+            shift_days = day_shifts[dept_id][bucket]
+            leaders = leader_flags[dept_id][bucket]
+            for day in shift_days:
+                if day not in leaders:
+                    missing += 1
+        info["missing_leaders"] = missing
+
+    return jsonify(sorted(overview.values(), key=lambda item: item["name"]))
 
 
 @app.post("/api/staff")

--- a/tests/test_department_schedule_api.py
+++ b/tests/test_department_schedule_api.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import importlib
+from datetime import date
+
+import pytest
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("DB_URL", f"sqlite:///{db_path}")
+
+    import models
+
+    importlib.reload(models)
+    models.init_db()
+
+    import app as app_module
+
+    importlib.reload(app_module)
+    return app_module.app.test_client(), models
+
+
+@pytest.fixture()
+def seeded(client):
+    app, models = client
+    with models.SessionLocal() as session:
+        dept_active = models.Department(
+            name="Support",
+            code="SUP",
+            color="#123456",
+            icon="Headphones",
+            settings={"min_staff_per_shift": 3},
+            is_active=True,
+        )
+        dept_inactive = models.Department(
+            name="Legacy",
+            code="LEG",
+            color="#654321",
+            icon="Archive",
+            is_active=False,
+        )
+        session.add_all([dept_active, dept_inactive])
+        session.flush()
+
+        alice = models.Staff(
+            full_name="Alice Leader",
+            role="TC",
+            department_id=dept_active.id,
+        )
+        bob = models.Staff(
+            full_name="Bob Worker",
+            role="GDV",
+            department_id=dept_active.id,
+        )
+        claire = models.Staff(
+            full_name="Claire Support",
+            role="GDV",
+            department_id=dept_active.id,
+        )
+        ian = models.Staff(
+            full_name="Ian Inactive",
+            role="TC",
+            department_id=dept_inactive.id,
+        )
+        session.add_all([alice, bob, claire, ian])
+        session.flush()
+
+        assignments = [
+            models.Assignment(
+                staff_id=alice.id,
+                day=date(2024, 9, 1),
+                shift_code="K",
+                position="TD",
+            ),
+            models.Assignment(
+                staff_id=bob.id,
+                day=date(2024, 9, 1),
+                shift_code="CA1",
+            ),
+            models.Assignment(
+                staff_id=alice.id,
+                day=date(2024, 9, 2),
+                shift_code="Đ",
+                position="TD",
+            ),
+            models.Assignment(
+                staff_id=bob.id,
+                day=date(2024, 9, 3),
+                shift_code="Đ",
+            ),
+            models.Assignment(
+                staff_id=claire.id,
+                day=date(2024, 9, 4),
+                shift_code="K",
+            ),
+            models.Assignment(
+                staff_id=ian.id,
+                day=date(2024, 9, 1),
+                shift_code="K",
+                position="TD",
+            ),
+        ]
+        session.add_all(assignments)
+        session.commit()
+
+    return app, models, {
+        "active_dept": dept_active.id,
+        "inactive_dept": dept_inactive.id,
+    }
+
+
+def test_list_departments_active_filter(seeded):
+    app, _models, meta = seeded
+
+    res = app.get("/api/departments?active=1")
+    assert res.status_code == 200
+    body = res.get_json()
+    assert len(body) == 1
+    assert body[0]["id"] == meta["active_dept"]
+    assert set(body[0].keys()) == {"id", "name", "code", "color", "icon", "settings"}
+
+    res = app.get("/api/departments?active=maybe")
+    assert res.status_code == 400
+
+
+def test_staff_filters_by_department_role_and_query(seeded):
+    app, _models, meta = seeded
+
+    res = app.get(
+        f"/api/staff?department_id={meta['active_dept']}&role=tc&q=alice"
+    )
+    assert res.status_code == 200
+    data = res.get_json()
+    assert len(data) == 1
+    assert data[0]["full_name"] == "Alice Leader"
+    assert data[0]["role"] == "TC"
+
+    res = app.get(f"/api/staff?department_id={meta['active_dept']}&role=gdv")
+    assert res.status_code == 200
+    names = [row["full_name"] for row in res.get_json()]
+    assert names == sorted(names)
+    assert names == ["Bob Worker", "Claire Support"]
+
+    res = app.get("/api/staff?q=ian")
+    assert res.status_code == 200
+    assert [row["full_name"] for row in res.get_json()] == ["Ian Inactive"]
+
+
+def test_get_schedule_filters_and_counts(seeded):
+    app, _models, meta = seeded
+
+    res = app.get(
+        f"/api/schedule?year=2024&month=9&department_id={meta['active_dept']}"
+    )
+    assert res.status_code == 200
+    payload = res.get_json()
+
+    items = payload["items"]
+    assert all(item["department_id"] == meta["active_dept"] for item in items)
+    assert {item["staff_name"] for item in items} == {
+        "Alice Leader",
+        "Bob Worker",
+        "Claire Support",
+    }
+
+    counts = payload["counts"]
+    assert counts["total"] == 5
+    assert counts["by_shift"] == {"K": 2, "CA1": 1, "Đ": 2}
+    assert counts["leaders"] == {"day": 1, "night": 1}
+
+
+def test_schedule_rejects_inactive_department(seeded):
+    app, _models, meta = seeded
+
+    res = app.get(
+        f"/api/schedule?year=2024&month=9&department_id={meta['inactive_dept']}"
+    )
+    assert res.status_code == 404
+
+
+def test_schedule_overview(seeded):
+    app, _models, meta = seeded
+
+    res = app.get("/api/schedule/overview?year=2024&month=9")
+    assert res.status_code == 200
+    body = res.get_json()
+
+    assert len(body) == 1
+    row = body[0]
+    assert row["department_id"] == meta["active_dept"]
+    assert row["shifts"] == 5
+    assert row["missing_leaders"] == 2
+    assert row["coverage_rate"] == pytest.approx(4 / 30, abs=1e-4)


### PR DESCRIPTION
## Summary
- add active-only filtering to the departments API and return a compact payload for switchers
- extend staff listing filters and prefetch departments to avoid N+1 queries
- expose schedule listing and overview endpoints with coverage metrics and document the new contracts
- add regression tests covering filtering, counts, and overview aggregation

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dff14477288320b95e7796d6848493